### PR TITLE
BUG FIX: fixing Birthday Song text to reflect actual gameplay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -371,7 +371,7 @@ function Card({
     if (catchable.key === "welcome_horizons") {
       note = t("Gifted at first concert");
     } else if (catchable.key === "kk_birthday") {
-      note = t("By concert request only (on birthday, or Saturday before)");
+      note = t("By concert request only (on birthday)");
     }
     noteSection = <Row icon={<Warning />}>{note}</Row>;
   }

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -327,7 +327,7 @@
     "Warrior statue": "Kriegerstatue",
     "Music": "Musik",
     "By concert request only": "Nur auf Konzertanfrage",
-    "By concert request only (on birthday, or Saturday before)": "Nur auf Konzertanfrage (Geburtstag oder Samstag davor)",
+    "By concert request only (on birthday)": "Nur auf Konzertanfrage (an deinem Geburtstag)",
     "Gifted at first concert": "Geschenk nach dem ersten Konzert",
     "Agent K.K.": "Agent K.K.",
     "Aloha K.K.": "K.K. Südseetraum",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -335,7 +335,7 @@
     "Warrior statue": "Estatua guerrera",
     "Music": "Canciones",
     "By concert request only": "Sólo por petición en un concierto",
-    "By concert request only (on birthday, or Saturday before)": "Sólo por petición en un concierto (en cumpleaños o el sábado anterior)",
+    "By concert request only (on birthday)": "Sólo por petición en un concierto (en su cumpleaños)",
     "Gifted at first concert": "Regalado en el primer concierto",
     "Agent K.K.": "Agente Totakeke",
     "Aloha K.K.": "Tota-aloha",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -335,7 +335,7 @@
     "Warrior statue": "Statue guerrière",
     "Music": "Chansons",
     "By concert request only": "Sur demande de concert uniquement",
-    "By concert request only (on birthday, or Saturday before)": "Sur demande de concert uniquement (jour de l’anniversaire ou samedi précédent)",
+    "By concert request only (on birthday)": "Sur demande de concert uniquement (pour ton anniversaire)",
     "Gifted at first concert": "Donné lors du premier concert",
     "Agent K.K.": "Agent Kéké",
     "Aloha K.K.": "Ukulélé Kéké",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -335,7 +335,7 @@
     "Warrior statue": "もののふのちょうこく",
     "Music": "とたけけソング",
     "By concert request only": "リクエストのみ",
-    "By concert request only (on birthday, or Saturday before)": "リクエストのみ（誕生日当日、または前週の土曜日）",
+    "By concert request only (on birthday)": "リクエストのみ（あなたの誕生日に）",
     "Gifted at first concert": "とたけけの初来日",
     "Agent K.K.": "けけけいじ",
     "Aloha K.K.": "アロハけけ",


### PR DESCRIPTION
I learned recently (on the Saturday before my birthday, actually) that in New Horizons, KK Slider refuses to perform the Birthday Song until your actual birthday. On the Saturday before, he says something about reserving that song for special occasions. 

You can see this mentioned in Nookipedia, too: https://nookipedia.com/wiki/Secret_song#K.K._Birthday