### PR TITLE
docs(readme): grammar fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Animal Crossing Catch
 
-Animal Crossing Catch is a mimimal, mobile friendly site for keeping track of fish and bugs you can catch in _Animal Crossing: New Horizons_.
+Animal Crossing Catch is a minimal, mobile friendly site for keeping track of fish and bugs you can catch in _Animal Crossing: New Horizons_.
 
 <img src="https://i.imgur.com/vxwNRi4.png" height="500" />
 
@@ -13,7 +13,7 @@ Animal Crossing Catch is a mimimal, mobile friendly site for keeping track of fi
 
 ## Building and running:
 
-The site is written using Typescript, React, and Create React App. The recommended way to get up and running is via Codesandbox which will give you an editable copy of the site right from your browser. You can then make an edit and open a pull request without downloading anything to your computer.
+The site is written using Typescript, React, and Create React App. The recommended way to get up and running is via CodeSandbox, which will give you an editable copy of the site right from your browser. You can then make an edit and open a pull request without downloading anything to your computer.
 
 [![Edit whatcanicatchnow](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/SawyerHood/animal-crossing-catch/tree/master/?fontsize=14&hidenavigation=1&theme=dark)
 
@@ -21,7 +21,7 @@ The site is written using Typescript, React, and Create React App. The recommend
 
 All of the data is currently generated from the animalcrossing Fandom wiki.
 
-We have a static process which will scrape the site, download the images, and generate files to be used by the main app. To update the data clone the repo locally and run the following:
+We have a static process that will scrape the site, download the images, and generate files to be used by the main app. To update the data clone the repo locally and run the following:
 
 ```
 cd scraper

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "",
   "keywords": [],
   "main": "src/index.tsx",
+  "repository": "git+https://github.com/SawyerHood/animal-crossing-catch.git",
+  "homepage": "https://github.com/SawyerHood/animal-crossing-catch",
+  "bugs": {
+    "url": "https://github.com/SawyerHood/animal-crossing-catch/issues"
+  },
   "dependencies": {
     "@types/lodash": "4.14.149",
     "emotion": "10.0.27",


### PR DESCRIPTION
Fixes a few grammatical issues in the readme file, and adds missing values to package.json to stop `npm i` and `yarn install` from throwing warnings